### PR TITLE
There should not be explicit typing deps, since python>=3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django (>=1.7)
 pytz
 six
-typing
+typing; python_version < "3.5"
 infi.clickhouse-orm
 celery
 statsd


### PR DESCRIPTION
There should not be explicit «typing» deps, since python>=3.5.

This leeds to explicit «typing» installation and broken python envs. 

See for example https://github.com/python/typing/issues/573 , https://github.com/psf/black/issues/1707 + … 

